### PR TITLE
Remove TS Project References

### DIFF
--- a/examples/with-css-modules/tsconfig.json
+++ b/examples/with-css-modules/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "references": [{ "path": "../../packages/react/tsconfig.build.json" }],
   "compilerOptions": {
     "target": "es2021",
     "skipLibCheck": true,

--- a/examples/with-function-calling/tsconfig.json
+++ b/examples/with-function-calling/tsconfig.json
@@ -17,8 +17,4 @@
     "strict": true,
     "target": "es2021"
   },
-  "references": [
-    { "path": "../../packages/core/tsconfig.build.json" },
-    { "path": "../../packages/react/tsconfig.build.json" }
-  ]
 }

--- a/examples/with-function-calling/tsconfig.json
+++ b/examples/with-function-calling/tsconfig.json
@@ -16,5 +16,5 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "es2021"
-  },
+  }
 }

--- a/examples/with-next/tsconfig.json
+++ b/examples/with-next/tsconfig.json
@@ -17,8 +17,4 @@
     "strict": true,
     "target": "es2021"
   },
-  "references": [
-    { "path": "../../packages/core/tsconfig.build.json" },
-    { "path": "../../packages/react/tsconfig.build.json" }
-  ]
 }

--- a/examples/with-next/tsconfig.json
+++ b/examples/with-next/tsconfig.json
@@ -16,5 +16,5 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "es2021"
-  },
+  }
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "stylelint": "^16.3.1",
     "stylelint-config-standard": "^36.0.0",
     "stylelint-formatter-github": "^1.0.1",
-    "turbo": "^2.0.1",
+    "turbo": "^2.0.6",
     "typescript": "^5.5.2",
     "typescript-eslint": "^7.7.0",
     "unified-prettier": "^2.0.1",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -21,7 +21,6 @@
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,
-    "composite": true,
 
     // runtime
     "lib": ["dom", "dom.iterable", "es2023"]

--- a/packages/docusaurus-theme-search/tsconfig.json
+++ b/packages/docusaurus-theme-search/tsconfig.json
@@ -21,7 +21,6 @@
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,
-    "composite": true,
     "jsx": "react-jsx",
     "verbatimModuleSyntax": true,
 
@@ -30,10 +29,6 @@
 
     "types": ["@docusaurus/module-type-aliases"]
   },
-  "references": [
-    { "path": "../core/tsconfig.build.json" },
-    { "path": "../react/tsconfig.build.json" }
-  ],
   "include": [".", ".eslintrc.cjs"],
   "exclude": ["dist/", ".turbo/"]
 }

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -22,14 +22,12 @@
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,
-    "composite": true,
     "jsx": "react-jsx",
     "verbatimModuleSyntax": true,
 
     // runtime
     "lib": ["dom", "dom.iterable", "es2023"]
   },
-  "references": [{ "path": "../core/tsconfig.build.json" }],
   "include": [".", ".eslintrc.cjs"],
   "exclude": ["dist/", ".turbo/"]
 }

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -34,10 +34,6 @@
       "react-dom": ["./node_modules/preact/compat"]
     }
   },
-  "references": [
-    { "path": "../core/tsconfig.build.json" },
-    { "path": "../react/tsconfig.build.json" }
-  ],
   "include": [".", ".eslintrc.cjs"],
   "exclude": ["dist/", ".turbo/"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,8 +102,8 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1(stylelint@16.4.0(typescript@5.5.2))
       turbo:
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.0.6
+        version: 2.0.6
       typescript:
         specifier: ^5.5.2
         version: 5.5.2
@@ -7967,38 +7967,38 @@ packages:
     engines: {node: '>=8.0.0'}
     hasBin: true
 
-  turbo-darwin-64@2.0.1:
-    resolution: {integrity: sha512-GO391pUmI6c6l/EpUIaXNzwbVDWRvYahm5oLB176dAWRYKYO+Osqs/XBdOM0G3l7ZFdR6nUtRJc8qinJp7qDUQ==}
+  turbo-darwin-64@2.0.6:
+    resolution: {integrity: sha512-XpgBwWj3Ggmz/gQVqXdMKXHC1iFPMDiuwugLwSzE7Ih0O13JuNtYZKhQnopvbDQnFQCeRq2Vsm5OTWabg/oB/g==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@2.0.1:
-    resolution: {integrity: sha512-rmjJoxeq7nmH/F2aWKapahrDE2zE2Uc15rvs4Rz6qHOzSqC8R5uyLpQyTKIPIZ95O/z9nKfLfVPyiRENuk5vpw==}
+  turbo-darwin-arm64@2.0.6:
+    resolution: {integrity: sha512-RfeZYXIAkiA21E8lsvfptGTqz/256YD+eI1x37fedfvnHFWuIMFZGAOwJxtZc6QasQunDZ9TRRREbJNI68tkIw==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@2.0.1:
-    resolution: {integrity: sha512-vwTOc4v4jm6tM+9WlsiDlN+zwHP8A2wlsAYiNqz2u0DZL55aCWaVdivh2VpVLN36Mr9HgREGH0Fw+jx6ObcNRg==}
+  turbo-linux-64@2.0.6:
+    resolution: {integrity: sha512-92UDa0xNQQbx0HdSp9ag3YSS3xPdavhc7q9q9mxIAcqyjjD6VElA4Y85m4F/DDGE5SolCrvBz2sQhVmkOd6Caw==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@2.0.1:
-    resolution: {integrity: sha512-DkVt76fjwY940DfmqznWhpYIlKYduvKAoTtylkERrDlcWUpDYWwqNbcf9PRRIbnjnv9lIxvuom1KZmMY+cw/Ig==}
+  turbo-linux-arm64@2.0.6:
+    resolution: {integrity: sha512-eQKu6utCVUkIH2kqOzD8OS6E0ba6COjWm6PRDTNCHQRljZW503ycaTUIdMOiJrVg1MkEjDyOReUg8s8D18aJ4Q==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@2.0.1:
-    resolution: {integrity: sha512-XskV34kYuXVIHbRbgH8jr35Y8uA6kJOQ0LJStU4jFk7piiyk0a4n2GNDymMtvIwAxYdbuTe+pKuPCThFdirHBQ==}
+  turbo-windows-64@2.0.6:
+    resolution: {integrity: sha512-+9u4EPrpoeHYCQ46dRcou9kbkSoelhOelHNcbs2d86D6ruYD/oIAHK9qgYK8LeARRz0jxhZIA/dWYdYsxJJWkw==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@2.0.1:
-    resolution: {integrity: sha512-R2/RmKr2uQxkOCtXK5LNxdD3Iv7lUm56iy2FrDwTDgPI7X7K6WRjrxdirmFIu/fABYE5n6EampU3ejbG5mmGtg==}
+  turbo-windows-arm64@2.0.6:
+    resolution: {integrity: sha512-rdrKL+p+EjtdDVg0wQ/7yTbzkIYrnb0Pw4IKcjsy3M0RqUM9UcEi67b94XOAyTa5a0GqJL1+tUj2ebsFGPgZbg==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@2.0.1:
-    resolution: {integrity: sha512-sJhxfBaN14pYj//xxAG6zAyStkE2j4HI9JVXVMob35SGob6dz/HuSqV/4QlVqw0uKAkwc1lXIsnykbe8RLmOOw==}
+  turbo@2.0.6:
+    resolution: {integrity: sha512-/Ftmxd5Mq//a9yMonvmwENNUN65jOVTwhhBPQjEtNZutYT9YKyzydFGLyVM1nzhpLWahQSMamRc/RDBv5EapzA==}
     hasBin: true
 
   type-check@0.4.0:
@@ -17649,32 +17649,32 @@ snapshots:
       wcwidth: 1.0.1
       yargs: 17.7.2
 
-  turbo-darwin-64@2.0.1:
+  turbo-darwin-64@2.0.6:
     optional: true
 
-  turbo-darwin-arm64@2.0.1:
+  turbo-darwin-arm64@2.0.6:
     optional: true
 
-  turbo-linux-64@2.0.1:
+  turbo-linux-64@2.0.6:
     optional: true
 
-  turbo-linux-arm64@2.0.1:
+  turbo-linux-arm64@2.0.6:
     optional: true
 
-  turbo-windows-64@2.0.1:
+  turbo-windows-64@2.0.6:
     optional: true
 
-  turbo-windows-arm64@2.0.1:
+  turbo-windows-arm64@2.0.6:
     optional: true
 
-  turbo@2.0.1:
+  turbo@2.0.6:
     optionalDependencies:
-      turbo-darwin-64: 2.0.1
-      turbo-darwin-arm64: 2.0.1
-      turbo-linux-64: 2.0.1
-      turbo-linux-arm64: 2.0.1
-      turbo-windows-64: 2.0.1
-      turbo-windows-arm64: 2.0.1
+      turbo-darwin-64: 2.0.6
+      turbo-darwin-arm64: 2.0.6
+      turbo-linux-64: 2.0.6
+      turbo-linux-arm64: 2.0.6
+      turbo-windows-64: 2.0.6
+      turbo-windows-arm64: 2.0.6
 
   type-check@0.4.0:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -18,7 +18,9 @@
     },
     "//#lint:md": {},
     "//#lint:ts": {},
-    "lint:ts": {},
+    "lint:ts": {
+      "dependsOn": ["^build"]
+    },
     "//#test": {
       "outputs": ["coverage/**"]
     }


### PR DESCRIPTION
Using TS Project References is [not recommended](https://turbo.build/repo/docs/guides/tools/typescript#you-likely-dont-need-typescript-project-references) while using Turbo as it introduces another layer of caching and complexity to your build config. This PR removes project references.